### PR TITLE
Add Docker image instructions and fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,11 +55,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v3
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,11 @@ RUN pnpm build
 # =============================================================================
 FROM debian:bookworm-slim
 
+# OCI labels for GitHub Container Registry
+LABEL org.opencontainers.image.source="https://github.com/getlawrence/lawrence-oss"
+LABEL org.opencontainers.image.description="OpenTelemetry agent management platform with built-in observability backend"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
 # Install runtime dependencies (including sqlite and C++ libs for DuckDB)
 RUN apt-get update && apt-get install -y \
     ca-certificates \

--- a/README.md
+++ b/README.md
@@ -20,6 +20,28 @@ Lawrence OSS manages OpenTelemetry collectors via OpAMP protocol and stores thei
 
 ## Getting Started
 
+### Run with Docker
+
+Pull and run the latest release:
+
+```bash
+# Pull the image
+docker pull ghcr.io/getlawrence/lawrence-oss:latest
+
+# Run Lawrence
+docker run -d \
+  --name lawrence \
+  -p 8080:8080 \
+  -p 4320:4320 \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  -v lawrence-data:/data \
+  ghcr.io/getlawrence/lawrence-oss:latest
+
+# Access the UI
+open http://localhost:8080
+```
+
 ### Run with Docker Compose
 
 ```bash


### PR DESCRIPTION
## Summary
- Added Docker run instructions to README for using published images
- Added OCI labels to Dockerfile for GitHub Container Registry linking
- Removed attestation step from release workflow (requires public repo or paid plan)

## Changes
### README
- Added "Run with Docker" section with pull and run commands
- Shows how to use the published image without cloning the repo

### Dockerfile
- Added OCI labels for proper GitHub Container Registry integration
- Links package to repository, adds description and license

### Release Workflow
- Removed attestation step that was causing failures
- Workflow will now complete successfully for public packages

## Testing
After this PR is merged, we can create a new release tag to test the full workflow with the public package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)