### PR TITLE
Enable multi-platform Docker builds (amd64 + arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+
+      # Set up QEMU for multi-platform builds
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      # Set up Docker Buildx for multi-platform builds
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
@@ -52,6 +61,7 @@ jobs:
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
Enables multi-platform Docker image builds to support both x86_64 and ARM64 architectures.

## Changes
- Added QEMU setup for cross-platform emulation
- Added Docker Buildx setup for multi-platform builds
- Configured build targets: `linux/amd64` and `linux/arm64`

## Benefits
- ✅ Native performance on Apple Silicon (M1/M2/M3/M4)
- ✅ Native performance on ARM64 servers (AWS Graviton, etc.)
- ✅ No platform mismatch warnings
- ✅ Single manifest with both architectures

## Testing Plan
After merge, create a new release tag and verify:
1. Image builds successfully for both platforms
2. Can pull and run without warnings on ARM64
3. Can pull and run on AMD64
4. Docker automatically selects the correct architecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)