### PR TITLE
feat: added worker pool for async processing

### DIFF
--- a/internal/worker/pool.go
+++ b/internal/worker/pool.go
@@ -1,0 +1,215 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/getlawrence/lawrence-oss/internal/otlp"
+	"github.com/getlawrence/lawrence-oss/internal/otlp/parser"
+	"github.com/getlawrence/lawrence-oss/internal/otlp/processor"
+	"github.com/getlawrence/lawrence-oss/internal/services"
+	"go.uber.org/zap"
+)
+
+// TelemetryWriter defines the interface for writing telemetry data
+type TelemetryWriter interface {
+	WriteTraces(ctx context.Context, traces []otlp.TraceData) error
+	WriteMetrics(ctx context.Context, sums []otlp.MetricSumData, gauges []otlp.MetricGaugeData, histograms []otlp.MetricHistogramData) error
+	WriteLogs(ctx context.Context, logs []otlp.LogData) error
+}
+
+// WorkItemType represents the type of work item
+type WorkItemType int
+
+const (
+	WorkItemTypeTraces WorkItemType = iota
+	WorkItemTypeMetrics
+	WorkItemTypeLogs
+)
+
+// WorkItem represents a single unit of work with raw OTLP bytes
+type WorkItem struct {
+	Type      WorkItemType
+	RawData   []byte // Raw protobuf bytes
+	Timestamp time.Time
+}
+
+// Pool represents a simple worker pool
+type Pool struct {
+	queue         chan WorkItem
+	shutdown      chan struct{}
+	wg            sync.WaitGroup
+	writer        TelemetryWriter
+	parser        *parser.OTLPParser
+	enricher      *processor.Enricher
+	logger        *zap.Logger
+	queueSize     int
+	submitTimeout time.Duration
+}
+
+// NewPool creates a new worker pool with a single worker
+func NewPool(queueSize int, writer TelemetryWriter, agentService services.AgentService, logger *zap.Logger) *Pool {
+	return &Pool{
+		queue:         make(chan WorkItem, queueSize),
+		shutdown:      make(chan struct{}),
+		writer:        writer,
+		parser:        parser.NewOTLPParser(logger),
+		enricher:      processor.NewEnricher(agentService, logger),
+		logger:        logger,
+		queueSize:     queueSize,
+		submitTimeout: 100 * time.Millisecond, // Timeout for submitting to queue
+	}
+}
+
+// Start starts the worker pool
+func (p *Pool) Start() {
+	p.logger.Info("Starting worker pool", zap.Int("workers", 1), zap.Int("queue_size", p.queueSize))
+	p.wg.Add(1)
+	go p.worker()
+}
+
+// Stop gracefully stops the worker pool
+func (p *Pool) Stop(timeout time.Duration) error {
+	p.logger.Info("Stopping worker pool", zap.Duration("timeout", timeout))
+
+	// Signal shutdown
+	close(p.shutdown)
+
+	// Wait for worker to finish with timeout
+	done := make(chan struct{})
+	go func() {
+		p.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		p.logger.Info("Worker pool stopped gracefully")
+		return nil
+	case <-time.After(timeout):
+		p.logger.Warn("Worker pool shutdown timeout", zap.Int("remaining_items", len(p.queue)))
+		return fmt.Errorf("shutdown timeout exceeded")
+	}
+}
+
+// Submit submits a work item to the queue
+func (p *Pool) Submit(item WorkItem) error {
+	select {
+	case p.queue <- item:
+		return nil
+	case <-time.After(p.submitTimeout):
+		return fmt.Errorf("queue full, submit timeout")
+	}
+}
+
+// QueueDepth returns the current queue depth
+func (p *Pool) QueueDepth() int {
+	return len(p.queue)
+}
+
+// worker is the main worker goroutine
+func (p *Pool) worker() {
+	defer p.wg.Done()
+
+	p.logger.Info("Worker started")
+
+	for {
+		select {
+		case item := <-p.queue:
+			p.processItem(item)
+		case <-p.shutdown:
+			// Drain remaining items
+			p.logger.Info("Draining remaining queue items", zap.Int("count", len(p.queue)))
+			for {
+				select {
+				case item := <-p.queue:
+					p.processItem(item)
+				default:
+					p.logger.Info("Worker stopped")
+					return
+				}
+			}
+		}
+	}
+}
+
+// processItem processes a single work item
+func (p *Pool) processItem(item WorkItem) {
+	start := time.Now()
+	ctx := context.Background()
+
+	var err error
+	var itemType string
+
+	switch item.Type {
+	case WorkItemTypeTraces:
+		itemType = "traces"
+
+		// Parse raw bytes
+		traces, err := p.parser.ParseTraces(item.RawData)
+		if err != nil {
+			p.logger.Error("Failed to parse traces", zap.Error(err))
+			return
+		}
+
+		// Enrich with group information
+		p.enricher.EnrichTraces(ctx, traces)
+
+		// Write to storage
+		err = p.writer.WriteTraces(ctx, traces)
+		p.logger.Debug("Processed traces",
+			zap.Int("count", len(traces)),
+			zap.Duration("duration", time.Since(start)),
+			zap.Error(err))
+
+	case WorkItemTypeMetrics:
+		itemType = "metrics"
+
+		// Parse raw bytes
+		sums, gauges, histograms, err := p.parser.ParseMetrics(item.RawData)
+		if err != nil {
+			p.logger.Error("Failed to parse metrics", zap.Error(err))
+			return
+		}
+
+		// Enrich with group information
+		p.enricher.EnrichMetrics(ctx, sums, gauges, histograms)
+
+		// Write to storage
+		err = p.writer.WriteMetrics(ctx, sums, gauges, histograms)
+		p.logger.Debug("Processed metrics",
+			zap.Int("sums", len(sums)),
+			zap.Int("gauges", len(gauges)),
+			zap.Int("histograms", len(histograms)),
+			zap.Duration("duration", time.Since(start)),
+			zap.Error(err))
+
+	case WorkItemTypeLogs:
+		itemType = "logs"
+
+		// Parse raw bytes
+		logs, err := p.parser.ParseLogs(item.RawData)
+		if err != nil {
+			p.logger.Error("Failed to parse logs", zap.Error(err))
+			return
+		}
+
+		// Enrich with group information
+		p.enricher.EnrichLogs(ctx, logs)
+
+		// Write to storage
+		err = p.writer.WriteLogs(ctx, logs)
+		p.logger.Debug("Processed logs",
+			zap.Int("count", len(logs)),
+			zap.Duration("duration", time.Since(start)),
+			zap.Error(err))
+	}
+
+	if err != nil {
+		p.logger.Error("Failed to process work item",
+			zap.String("type", itemType),
+			zap.Error(err))
+	}
+}


### PR DESCRIPTION
This pull request introduces a significant architectural change to how telemetry data (traces, metrics, logs) is processed in the system. Instead of parsing and enriching telemetry synchronously in the gRPC and HTTP receivers, all incoming telemetry data is now queued and processed asynchronously by a centralized worker pool. This improves scalability and reliability by decoupling ingestion from processing, and also simplifies the receiver code. Additionally, request logging for the HTTP API server is now less verbose, reducing log noise for health checks and routine requests.

**Telemetry ingestion pipeline refactor:**

* Replaces synchronous parsing and enrichment in OTLP gRPC and HTTP receivers with asynchronous processing via a new `worker.Pool`. All telemetry data is now submitted as raw bytes to the worker pool, which handles parsing, enrichment, and storage. (`cmd/all-in-one/main.go`, `integration/integration/test_server.go`, `internal/otlp/receiver/grpc_handlers.go`, `internal/otlp/receiver/grpc_server.go`, `internal/otlp/receiver/http_server.go`) [[1]](diffhunk://#diff-0888ca3408f76362e5e951617b16f40ac09e6ff66e400f48097903f2289f4d8bL21-R26) [[2]](diffhunk://#diff-cff5103fa7d05e31b396367e731b3be1271d0593c46a9976f1f8f4527814af67L20-R27) [[3]](diffhunk://#diff-cff5103fa7d05e31b396367e731b3be1271d0593c46a9976f1f8f4527814af67L203-R217) [[4]](diffhunk://#diff-cff5103fa7d05e31b396367e731b3be1271d0593c46a9976f1f8f4527814af67R272-R276) [[5]](diffhunk://#diff-a737329b5ca322ef1cfab4fb32d824808abf3931c4a36d302df1ab2b380932e3L8-R8) [[6]](diffhunk://#diff-a737329b5ca322ef1cfab4fb32d824808abf3931c4a36d302df1ab2b380932e3L23-R66) [[7]](diffhunk://#diff-a737329b5ca322ef1cfab4fb32d824808abf3931c4a36d302df1ab2b380932e3L115-R136) [[8]](diffhunk://#diff-a737329b5ca322ef1cfab4fb32d824808abf3931c4a36d302df1ab2b380932e3L194-R186) [[9]](diffhunk://#diff-a737329b5ca322ef1cfab4fb32d824808abf3931c4a36d302df1ab2b380932e3L249-R230) [[10]](diffhunk://#diff-584e891ec163f67972a608472485e78d9523f01a3614af5ff7037eee125f0049L10-R10) [[11]](diffhunk://#diff-584e891ec163f67972a608472485e78d9523f01a3614af5ff7037eee125f0049L32-R31) [[12]](diffhunk://#diff-584e891ec163f67972a608472485e78d9523f01a3614af5ff7037eee125f0049L49-R47) [[13]](diffhunk://#diff-fb13dafc676ccf6cd8aa66006ae74e315bbc9aa6e3cde63dbea68b10d2037829L11-R11)

* Updates the initialization and shutdown logic in both the main application and integration test server to start and stop the worker pool appropriately, ensuring graceful shutdown and resource cleanup. (`cmd/all-in-one/main.go`, `integration/integration/test_server.go`) [[1]](diffhunk://#diff-0888ca3408f76362e5e951617b16f40ac09e6ff66e400f48097903f2289f4d8bL180-R177) [[2]](diffhunk://#diff-cff5103fa7d05e31b396367e731b3be1271d0593c46a9976f1f8f4527814af67R56-R58) [[3]](diffhunk://#diff-cff5103fa7d05e31b396367e731b3be1271d0593c46a9976f1f8f4527814af67R272-R276)

* Removes now-unnecessary references to the `processor.Enricher` and synchronous parser logic from the receivers, simplifying constructor signatures and internal logic. (`cmd/all-in-one/main.go`, `integration/integration/test_server.go`, `internal/otlp/receiver/grpc_handlers.go`, `internal/otlp/receiver/grpc_server.go`, `internal/otlp/receiver/http_server.go`) [[1]](diffhunk://#diff-0888ca3408f76362e5e951617b16f40ac09e6ff66e400f48097903f2289f4d8bL180-R177) [[2]](diffhunk://#diff-cff5103fa7d05e31b396367e731b3be1271d0593c46a9976f1f8f4527814af67L203-R217) [[3]](diffhunk://#diff-a737329b5ca322ef1cfab4fb32d824808abf3931c4a36d302df1ab2b380932e3L8-R8) [[4]](diffhunk://#diff-a737329b5ca322ef1cfab4fb32d824808abf3931c4a36d302df1ab2b380932e3L23-R66) [[5]](diffhunk://#diff-584e891ec163f67972a608472485e78d9523f01a3614af5ff7037eee125f0049L10-R10) [[6]](diffhunk://#diff-584e891ec163f67972a608472485e78d9523f01a3614af5ff7037eee125f0049L32-R31) [[7]](diffhunk://#diff-584e891ec163f67972a608472485e78d9523f01a3614af5ff7037eee125f0049L49-R47) [[8]](diffhunk://#diff-fb13dafc676ccf6cd8aa66006ae74e315bbc9aa6e3cde63dbea68b10d2037829L11-R11)

**Logging improvements:**

* Refines the HTTP API server's logging middleware to reduce verbosity: health and readiness checks are no longer logged, errors are logged at INFO level, and all other requests are logged at DEBUG level to minimize log noise. (`internal/api/server.go`)

These changes collectively improve the system's scalability and maintainability by decoupling ingestion from processing and reducing unnecessary log output.