### PR TITLE
fix: allow runtime backend url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,10 @@ RUN npm install -g pnpm
 # Set working directory
 WORKDIR /app
 
+# Allow builders to override the default backend URL used at build time.
+ARG VITE_BACKEND_URL=http://localhost:8080
+ENV VITE_BACKEND_URL=${VITE_BACKEND_URL}
+
 # Copy package files
 COPY ui/package.json ui/pnpm-lock.yaml ./
 
@@ -89,6 +93,10 @@ COPY --from=frontend-builder /app/dist ./ui/dist
 # Copy configuration
 COPY lawrence.yaml .
 
+# Copy runtime entrypoint for injecting frontend config
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 # Create data directory
 RUN mkdir -p /app/data && \
     chown -R lawrence:lawrence /app
@@ -111,5 +119,6 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 ENV GIN_MODE=release
 ENV TZ=UTC
 
+ENTRYPOINT ["/entrypoint.sh"]
 # Run the application
 CMD ["./lawrence"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# Allow operators to supply a backend URL at runtime without rebuilding the UI bundle.
+# When BACKEND_URL (or VITE_BACKEND_URL for backwards compatibility) is set,
+# replace the placeholder token inside the generated runtime config file.
+
+CONFIG_PATH="/app/ui/dist/lawrence-config.js"
+CONFIG_TEMPLATE_PATH="/app/ui/dist/lawrence-config.js.template"
+RUNTIME_URL="${BACKEND_URL:-${VITE_BACKEND_URL:-}}"
+
+if [ -f "$CONFIG_PATH" ] && [ ! -f "$CONFIG_TEMPLATE_PATH" ]; then
+  cp "$CONFIG_PATH" "$CONFIG_TEMPLATE_PATH"
+fi
+
+if [ -f "$CONFIG_TEMPLATE_PATH" ]; then
+  cp "$CONFIG_TEMPLATE_PATH" "$CONFIG_PATH"
+fi
+
+if [ -n "$RUNTIME_URL" ] && [ -f "$CONFIG_PATH" ]; then
+  # Escape characters that sed treats as special.
+  ESCAPED_URL=$(printf '%s\n' "$RUNTIME_URL" | sed 's/[\/&]/\\&/g')
+  sed -i "s|__LAWRENCE_BACKEND_URL__|$ESCAPED_URL|g" "$CONFIG_PATH"
+fi
+
+exec "$@"
+

--- a/ui/index.html
+++ b/ui/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="/lawrence-config.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/ui/public/lawrence-config.js
+++ b/ui/public/lawrence-config.js
@@ -1,0 +1,13 @@
+(function () {
+  const placeholder = "__LAWRENCE_BACKEND_URL__";
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.__LAWRENCE_CONFIG__ = window.__LAWRENCE_CONFIG__ ?? {};
+
+  if (!window.__LAWRENCE_CONFIG__.backendUrl) {
+    window.__LAWRENCE_CONFIG__.backendUrl = placeholder;
+  }
+})();
+

--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -1,19 +1,36 @@
-// OSS Configuration - simplified for local development
+declare global {
+  interface Window {
+    __LAWRENCE_CONFIG__?: {
+      backendUrl?: string;
+    };
+  }
+}
+
+const PLACEHOLDER = "__LAWRENCE_BACKEND_URL__";
+
+const runtimeBackendUrl =
+  typeof window !== "undefined"
+    ? window.__LAWRENCE_CONFIG__?.backendUrl
+    : undefined;
+
+const sanitizedRuntimeUrl =
+  runtimeBackendUrl && runtimeBackendUrl !== PLACEHOLDER
+    ? runtimeBackendUrl
+    : undefined;
+
+const sameOriginUrl =
+  typeof window !== "undefined" ? window.location.origin : undefined;
+
+const buildTimeUrl =
+  import.meta.env.VITE_BACKEND_URL &&
+  import.meta.env.VITE_BACKEND_URL !== PLACEHOLDER
+    ? import.meta.env.VITE_BACKEND_URL
+    : undefined;
+
 export const BACKEND_HOSTNAME =
-  import.meta.env.VITE_BACKEND_URL ||
-  (import.meta.env.MODE === "production"
-    ? "http://localhost:8080"
-    : "http://localhost:8080");
+  sanitizedRuntimeUrl ??
+  sameOriginUrl ??
+  buildTimeUrl ??
+  "http://localhost:8080";
+
 export const apiBaseUrl = `${BACKEND_HOSTNAME}/api/v1`;
-export const socketIOUrl = BACKEND_HOSTNAME;
-export const API_BASE_URL = apiBaseUrl;
-
-// Application URLs
-export const APP_BASE_URL =
-  import.meta.env.VITE_APP_BASE_URL ||
-  (import.meta.env.MODE === "production"
-    ? "http://localhost:5173"
-    : "http://localhost:5173");
-
-// OSS version doesn't use Clerk authentication
-export const CLERK_PUBLISHABLE_KEY = null;


### PR DESCRIPTION
## Summary
- add runtime configuration loading for frontend backend URL
- allow runtime overrides via entrypoint and same-origin fallback

Fixes #16